### PR TITLE
Add support for global object acls

### DIFF
--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -85,6 +85,7 @@ return array(
     'OCA\\Files_External1\\Lib\\StorageConfig' => $baseDir . '/../lib/Lib/StorageConfig.php',
     'OCA\\Files_External1\\Lib\\StorageModifierTrait' => $baseDir . '/../lib/Lib/StorageModifierTrait.php',
     'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => $baseDir . '/../lib/Lib/Storage/AmazonS3.php',
+    'OCA\\Files_External1\\Lib\\Trait\\AmazonS3' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
     'OCA\\Files_External1\\Lib\\Storage\\FTP' => $baseDir . '/../lib/Lib/Storage/FTP.php',
     'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => $baseDir . '/../lib/Lib/Storage/FtpConnection.php',
     'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => $baseDir . '/../lib/Lib/Storage/OwnCloud.php',

--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -85,7 +85,7 @@ return array(
     'OCA\\Files_External1\\Lib\\StorageConfig' => $baseDir . '/../lib/Lib/StorageConfig.php',
     'OCA\\Files_External1\\Lib\\StorageModifierTrait' => $baseDir . '/../lib/Lib/StorageModifierTrait.php',
     'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => $baseDir . '/../lib/Lib/Storage/AmazonS3.php',
-    'OCA\\Files_External1\\Lib\\Trait\\AmazonS3' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
+    'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
     'OCA\\Files_External1\\Lib\\Storage\\FTP' => $baseDir . '/../lib/Lib/Storage/FTP.php',
     'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => $baseDir . '/../lib/Lib/Storage/FtpConnection.php',
     'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => $baseDir . '/../lib/Lib/Storage/OwnCloud.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -100,7 +100,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External1\\Lib\\StorageConfig' => __DIR__ . '/..' . '/../lib/Lib/StorageConfig.php',
         'OCA\\Files_External1\\Lib\\StorageModifierTrait' => __DIR__ . '/..' . '/../lib/Lib/StorageModifierTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => __DIR__ . '/..' . '/../lib/Lib/Storage/AmazonS3.php',
-        'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
+        'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => __DIR__ . '/../lib/Lib/Trait/S3ObjectTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\FTP' => __DIR__ . '/..' . '/../lib/Lib/Storage/FTP.php',
         'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => __DIR__ . '/..' . '/../lib/Lib/Storage/FtpConnection.php',
         'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => __DIR__ . '/..' . '/../lib/Lib/Storage/OwnCloud.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -100,7 +100,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External1\\Lib\\StorageConfig' => __DIR__ . '/..' . '/../lib/Lib/StorageConfig.php',
         'OCA\\Files_External1\\Lib\\StorageModifierTrait' => __DIR__ . '/..' . '/../lib/Lib/StorageModifierTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => __DIR__ . '/..' . '/../lib/Lib/Storage/AmazonS3.php',
-        'OCA\\Files_External1\\Lib\\Trait\\AmazonS3' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
+        'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\FTP' => __DIR__ . '/..' . '/../lib/Lib/Storage/FTP.php',
         'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => __DIR__ . '/..' . '/../lib/Lib/Storage/FtpConnection.php',
         'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => __DIR__ . '/..' . '/../lib/Lib/Storage/OwnCloud.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -100,7 +100,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External1\\Lib\\StorageConfig' => __DIR__ . '/..' . '/../lib/Lib/StorageConfig.php',
         'OCA\\Files_External1\\Lib\\StorageModifierTrait' => __DIR__ . '/..' . '/../lib/Lib/StorageModifierTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => __DIR__ . '/..' . '/../lib/Lib/Storage/AmazonS3.php',
-        'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => __DIR__ . '/../lib/Lib/Trait/S3ObjectTrait.php',
+        'OCA\\Files_External1\\Lib\\Trait\\S3ObjectTrait' => __DIR__ . '/..' . '/../lib/Lib/Trait/S3ObjectTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\FTP' => __DIR__ . '/..' . '/../lib/Lib/Storage/FTP.php',
         'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => __DIR__ . '/..' . '/../lib/Lib/Storage/FtpConnection.php',
         'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => __DIR__ . '/..' . '/../lib/Lib/Storage/OwnCloud.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -100,6 +100,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External1\\Lib\\StorageConfig' => __DIR__ . '/..' . '/../lib/Lib/StorageConfig.php',
         'OCA\\Files_External1\\Lib\\StorageModifierTrait' => __DIR__ . '/..' . '/../lib/Lib/StorageModifierTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\AmazonS3' => __DIR__ . '/..' . '/../lib/Lib/Storage/AmazonS3.php',
+        'OCA\\Files_External1\\Lib\\Trait\\AmazonS3' => $baseDir . '/../lib/Lib/Trait/S3ObjectTrait.php',
         'OCA\\Files_External1\\Lib\\Storage\\FTP' => __DIR__ . '/..' . '/../lib/Lib/Storage/FTP.php',
         'OCA\\Files_External1\\Lib\\Storage\\FtpConnection' => __DIR__ . '/..' . '/../lib/Lib/Storage/FtpConnection.php',
         'OCA\\Files_External1\\Lib\\Storage\\OwnCloud' => __DIR__ . '/..' . '/../lib/Lib/Storage/OwnCloud.php',

--- a/js/settings.js
+++ b/js/settings.js
@@ -1098,6 +1098,7 @@ MountConfigListView.prototype = _.extend({
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.HIDDEN) {
 			newElement = $('<input type="hidden" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />');
 		} else {
+			console.log(parameter);
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1098,7 +1098,7 @@ MountConfigListView.prototype = _.extend({
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.HIDDEN) {
 			newElement = $('<input type="hidden" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />');
 		} else {
-			console.log(parameter);
+			console.log(parameter, placeholder);
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -610,7 +610,8 @@ MountConfigListView.ParameterTypes = {
 	TEXT: 0,
 	BOOLEAN: 1,
 	PASSWORD: 2,
-	HIDDEN: 3
+	HIDDEN: 3,
+	SELECT: 4
 };
 
 /**
@@ -1097,8 +1098,13 @@ MountConfigListView.prototype = _.extend({
 			newElement = $('<div><label><input type="checkbox" id="'+checkboxId+'" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />'+ trimmedPlaceholder+'</label></div>');
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.HIDDEN) {
 			newElement = $('<input type="hidden" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />');
+		} else if (placeholder.type === MountConfigListView.ParameterTypes.SELECT) {
+			newElement = $('<select class="'+classes.join(' ')+'" data-parameter="'+parameter+'"></select>');
+			$.each(placeholder.options, function(value, label) {
+				newElement.append($('<option value="'+value+'">'+label+'</option>'));
+			});
 		} else {
-			console.log(parameter, placeholder);
+			console.log(parameter, placeholder, $td);
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1099,12 +1099,12 @@ MountConfigListView.prototype = _.extend({
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.HIDDEN) {
 			newElement = $('<input type="hidden" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" />');
 		} else if (placeholder.type === MountConfigListView.ParameterTypes.SELECT) {
+			console.log(parameter, placeholder, $td, this);
 			newElement = $('<select class="'+classes.join(' ')+'" data-parameter="'+parameter+'"></select>');
 			$.each(placeholder.options, function(value, label) {
 				newElement.append($('<option value="'+value+'">'+label+'</option>'));
 			});
 		} else {
-			console.log(parameter, placeholder, $td);
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1148,7 +1148,7 @@ MountConfigListView.prototype = _.extend({
 		storage.authMechanism = $tr.find('.selectAuthMechanism').val();
 
 		var classOptions = {};
-		var configuration = $tr.find('.configuration input');
+		var configuration = $tr.find('.configuration input, .configuration select');
 		var missingOptions = [];
 		$.each(configuration, function(index, input) {
 			var $input = $(input);

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -155,6 +155,13 @@ OC.L10N.register(
     "Credentials saving failed" : "Credentials saving failed",
     "Credentials required" : "Credentials required",
     "Disabling it will allow to use a case insentive file system, but comes with a performance penalty" : "Disabling it will allow to use a case insentive file system, but comes with a performance penalty",
-    "Name" : "Name"
+    "Name" : "Name",
+    "Acl" : "ACL",
+    "Private" : "Private",
+    "Public Read": "Public Read",
+    "Public Read/Write": "Public Read/Write",
+    "Authenticated Read": "Authenticated Read",
+    "Bucket Owner Read": "Bucket Owner Read",
+    "Bucket Owner Full Control": "Bucket Owner Full Control"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -153,6 +153,13 @@
     "Credentials saving failed" : "Credentials saving failed",
     "Credentials required" : "Credentials required",
     "Disabling it will allow to use a case insentive file system, but comes with a performance penalty" : "Disabling it will allow to use a case insentive file system, but comes with a performance penalty",
-    "Name" : "Name"
+    "Name" : "Name",
+    "Acl" : "ACL",
+    "Private" : "Private",
+    "Public Read": "Public Read",
+    "Public Read/Write": "Public Read/Write",
+    "Authenticated Read": "Authenticated Read",
+    "Bucket Owner Read": "Bucket Owner Read",
+    "Bucket Owner Full Control": "Bucket Owner Full Control"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Lib/Backend/AmazonS3.php
+++ b/lib/Lib/Backend/AmazonS3.php
@@ -48,8 +48,8 @@ class AmazonS3 extends Backend
                 (new DefinitionParameter('name', $l->t('Name')))
                     ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
                 (new DefinitionParameter('acl', $l->t('Acl')))
-                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL)
                     ->setType(DefinitionParameter::VALUE_SELECT)
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL)
                     ->setOptions([
                         ''                          => $l->t('None'),
                         'private'                   => $l->t('Private'),
@@ -58,7 +58,8 @@ class AmazonS3 extends Backend
                         'authenticated-read'        => $l->t('Authenticated Read'),
                         'bucket-owner-read'         => $l->t('Bucket Owner Read'),
                         'bucket-owner-full-control' => $l->t('Bucket Owner Full Control'),
-                    ]),
+                    ])
+                    ->setDefaultValue(''),
                 (new DefinitionParameter('hostname', $l->t('Hostname')))
                     ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
                 (new DefinitionParameter('port', $l->t('Port')))

--- a/lib/Lib/Backend/AmazonS3.php
+++ b/lib/Lib/Backend/AmazonS3.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -22,6 +23,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\Files_External1\Lib\Backend;
 
 use OCA\Files_External1\Lib\Auth\AmazonS3\AccessKey;
@@ -30,38 +32,51 @@ use OCA\Files_External1\Lib\DefinitionParameter;
 use OCA\Files_External1\Lib\LegacyDependencyCheckPolyfill;
 use OCP\IL10N;
 
-class AmazonS3 extends Backend {
-	use LegacyDependencyCheckPolyfill;
+class AmazonS3 extends Backend
+{
+    use LegacyDependencyCheckPolyfill;
 
-	public function __construct(IL10N $l, AccessKey $legacyAuth) {
-		$this
-			->setIdentifier('amazons3')
-			->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
-			->setStorageClass('\OCA\Files_External1\Lib\Storage\AmazonS3')
-			->setText($l->t('Amazon S3'))
-			->addParameters([
-				new DefinitionParameter('bucket', $l->t('Bucket')),
-				(new DefinitionParameter('name', $l->t('Name')))
-                                        ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('hostname', $l->t('Hostname')))
-					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('port', $l->t('Port')))
-					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('region', $l->t('Region')))
-					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('storageClass', $l->t('Storage Class')))
-					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN)
-					->setDefaultValue(true),
-				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
-				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
-			])
-			->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
-			->addAuthScheme(AuthMechanism::SCHEME_NULL)
-			->setLegacyAuthMechanism($legacyAuth)
-		;
-	}
+    public function __construct(IL10N $l, AccessKey $legacyAuth)
+    {
+        $this
+            ->setIdentifier('amazons3')
+            ->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
+            ->setStorageClass('\OCA\Files_External1\Lib\Storage\AmazonS3')
+            ->setText($l->t('Amazon S3'))
+            ->addParameters([
+                new DefinitionParameter('bucket', $l->t('Bucket')),
+                (new DefinitionParameter('name', $l->t('Name')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+                (new DefinitionParameter('acl', $l->t('Acl')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL)
+                    ->setType(DefinitionParameter::VALUE_SELECT)
+                    ->setOptions([
+                        ''                          => $l->t('None'),
+                        'private'                   => $l->t('Private'),
+                        'public-read'               => $l->t('Public Read'),
+                        'public-read-write'         => $l->t('Public Read/Write'),
+                        'authenticated-read'        => $l->t('Authenticated Read'),
+                        'bucket-owner-read'         => $l->t('Bucket Owner Read'),
+                        'bucket-owner-full-control' => $l->t('Bucket Owner Full Control'),
+                    ]),
+                (new DefinitionParameter('hostname', $l->t('Hostname')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+                (new DefinitionParameter('port', $l->t('Port')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+                (new DefinitionParameter('region', $l->t('Region')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+                (new DefinitionParameter('storageClass', $l->t('Storage Class')))
+                    ->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+                (new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
+                    ->setType(DefinitionParameter::VALUE_BOOLEAN)
+                    ->setDefaultValue(true),
+                (new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
+                    ->setType(DefinitionParameter::VALUE_BOOLEAN),
+                (new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
+                    ->setType(DefinitionParameter::VALUE_BOOLEAN),
+            ])
+            ->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
+            ->addAuthScheme(AuthMechanism::SCHEME_NULL)
+            ->setLegacyAuthMechanism($legacyAuth);
+    }
 }

--- a/lib/Lib/DefinitionParameter.php
+++ b/lib/Lib/DefinitionParameter.php
@@ -36,6 +36,7 @@ class DefinitionParameter implements \JsonSerializable {
 	public const VALUE_BOOLEAN = 1;
 	public const VALUE_PASSWORD = 2;
 	public const VALUE_HIDDEN = 3;
+	public const VALUE_SELECT = 4;
 
 	/** Flag constants */
 	public const FLAG_NONE = 0;
@@ -56,6 +57,9 @@ class DefinitionParameter implements \JsonSerializable {
 
 	/** @var int flags, see self::FLAG_* constants */
 	private int $flags = self::FLAG_NONE;
+
+	/** @var array options, used to populate a set of options in a select. */
+	private $options = [];
 
 	/** @var mixed */
 	private $defaultValue;
@@ -135,6 +139,14 @@ class DefinitionParameter implements \JsonSerializable {
 			default:
 				return 'unknown';
 		}
+	}
+
+	public function getOptions(): array {
+		return $this->options;
+	}
+
+	public function setOptions(array $optionsArray) {
+		$this->options = $optionsArray;
 	}
 
 	/**

--- a/lib/Lib/DefinitionParameter.php
+++ b/lib/Lib/DefinitionParameter.php
@@ -136,6 +136,8 @@ class DefinitionParameter implements \JsonSerializable {
 				return 'text';
 			case self::VALUE_PASSWORD:
 				return 'password';
+			case self::VALUE_SELECT:
+				return 'select';
 			default:
 				return 'unknown';
 		}

--- a/lib/Lib/DefinitionParameter.php
+++ b/lib/Lib/DefinitionParameter.php
@@ -147,6 +147,7 @@ class DefinitionParameter implements \JsonSerializable {
 
 	public function setOptions(array $optionsArray) {
 		$this->options = $optionsArray;
+		return $this;
 	}
 
 	/**

--- a/lib/Lib/DefinitionParameter.php
+++ b/lib/Lib/DefinitionParameter.php
@@ -211,6 +211,9 @@ class DefinitionParameter implements \JsonSerializable {
 			'type' => $this->getType(),
 			'tooltip' => $this->getTooltip(),
 		];
+		if ($this->getType() === self::VALUE_SELECT) {
+			$result['options'] = $this->getOptions();
+		}
 		$defaultValue = $this->getDefaultValue();
 		if ($defaultValue) {
 			$result['defaultValue'] = $defaultValue;

--- a/lib/Lib/Storage/AmazonS3.php
+++ b/lib/Lib/Storage/AmazonS3.php
@@ -264,6 +264,13 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
+			$this->logger->debug('Calling put object' . $path, $this->getPayloadWithACLIfSet([
+				'Bucket' => $this->bucket,
+				'Key' => $path . '/',
+				'Body' => '',
+				'ContentType' => FileInfo::MIMETYPE_FOLDER
+			]));
+
 			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $path . '/',
@@ -568,6 +575,15 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			}
 
 			$mimeType = $this->mimeDetector->detectPath($path);
+			$this->logger->debug('Calling put object' . $path, $this->getPayloadWithACLIfSet([
+				'Bucket' => $this->bucket,
+				'Key' => $this->cleanKey($path),
+				'Metadata' => $metadata,
+				'Body' => '',
+				'ContentType' => $mimeType,
+				'MetadataDirective' => 'REPLACE',
+			]));
+
 			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey($path),

--- a/lib/Lib/Storage/AmazonS3.php
+++ b/lib/Lib/Storage/AmazonS3.php
@@ -100,9 +100,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	}
 
 	private function getPayloadWithACLIfSet(array $payload): array {
-		$this->logger->info('AmazonS3', $this->params);
 		if (isset($this->params['acl'])) {
 			$payload['ACL'] = $this->params['acl'];
+		} else {
+			$payload['ACL'] = 'private'; // Default to private.
 		}
 
 		return $payload;
@@ -265,13 +266,6 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			$this->logger->info('Calling put object' . $path, $this->getPayloadWithACLIfSet([
-				'Bucket' => $this->bucket,
-				'Key' => $path . '/',
-				'Body' => '',
-				'ContentType' => FileInfo::MIMETYPE_FOLDER
-			]));
-
 			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $path . '/',
@@ -576,15 +570,6 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			}
 
 			$mimeType = $this->mimeDetector->detectPath($path);
-			$this->logger->info('Calling put object' . $path, $this->getPayloadWithACLIfSet([
-				'Bucket' => $this->bucket,
-				'Key' => $this->cleanKey($path),
-				'Metadata' => $metadata,
-				'Body' => '',
-				'ContentType' => $mimeType,
-				'MetadataDirective' => 'REPLACE',
-			]));
-
 			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey($path),

--- a/lib/Lib/Storage/AmazonS3.php
+++ b/lib/Lib/Storage/AmazonS3.php
@@ -80,7 +80,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	public function __construct($parameters) {
 		parent::__construct($parameters);
 		$this->parseParams($parameters);
-		$this->id = 'amazon::external::' . md5($this->params['hostname'] . ':' . $this->params['name'] . ':' . $this->params['bucket'] . ':' . $this->params['key']);
+		$this->id = $this->getUniqueId();
 		$this->objectCache = new CappedMemoryCache();
 		$this->directoryCache = new CappedMemoryCache();
 		$this->filesCache = new CappedMemoryCache();
@@ -89,6 +89,22 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$cacheFactory = Server::get(ICacheFactory::class);
 		$this->memCache = $cacheFactory->createLocal('s3-external');
 		$this->logger = Server::get(LoggerInterface::class);
+	}
+
+	private function getSafeParam($key, $default = null) {
+		return $this->params[$key] ?? $default;
+	}
+
+	private function getUniqueId(): string {
+		return 'amazon::external::' . md5($this->getSafeParam('hostname') . ':' . $this->getSafeParam('name') . ':' . $this->getSafeParam('bucket') . ':' . $this->getSafeParam('key', 'no-key'));
+	}
+
+	private function getPayloadWithACLIfSet(array $payload): array {
+		if (isset($this->params['acl'])) {
+			$payload['ACL'] = $this->params['acl'];
+		}
+
+		return $payload;
 	}
 
 	/**
@@ -248,12 +264,12 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			$this->getConnection()->putObject([
+			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $path . '/',
 				'Body' => '',
 				'ContentType' => FileInfo::MIMETYPE_FOLDER
-			]);
+			]));
 			$this->testTimeout();
 		} catch (S3Exception $e) {
 			$this->logger->error($e->getMessage(), [
@@ -552,14 +568,14 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			}
 
 			$mimeType = $this->mimeDetector->detectPath($path);
-			$this->getConnection()->putObject([
+			$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey($path),
 				'Metadata' => $metadata,
 				'Body' => '',
 				'ContentType' => $mimeType,
 				'MetadataDirective' => 'REPLACE',
-			]);
+			]));
 			$this->testTimeout();
 		} catch (S3Exception $e) {
 			$this->logger->error($e->getMessage(), [
@@ -579,9 +595,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 		if ($isFile === true || $this->is_file($source)) {
 			try {
-				$this->copyObject($source, $target, [
+				$this->copyObject($source, $target, $this->getPayloadWithACLIfSet([
 					'StorageClass' => $this->storageClass,
-				]);
+				]));
 				$this->testTimeout();
 			} catch (S3Exception $e) {
 				$this->logger->error($e->getMessage(), [

--- a/lib/Lib/Storage/AmazonS3.php
+++ b/lib/Lib/Storage/AmazonS3.php
@@ -44,7 +44,7 @@ use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\ObjectStore\S3ConnectionTrait;
-use OC\Files\ObjectStore\S3ObjectTrait;
+use OCA\Files_External1\Lib\Trait\S3ObjectTrait;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\FileInfo;
@@ -100,6 +100,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	}
 
 	private function getPayloadWithACLIfSet(array $payload): array {
+		$this->logger->info('AmazonS3', $this->params);
 		if (isset($this->params['acl'])) {
 			$payload['ACL'] = $this->params['acl'];
 		}
@@ -264,7 +265,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			$this->logger->debug('Calling put object' . $path, $this->getPayloadWithACLIfSet([
+			$this->logger->info('Calling put object' . $path, $this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $path . '/',
 				'Body' => '',
@@ -575,7 +576,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			}
 
 			$mimeType = $this->mimeDetector->detectPath($path);
-			$this->logger->debug('Calling put object' . $path, $this->getPayloadWithACLIfSet([
+			$this->logger->info('Calling put object' . $path, $this->getPayloadWithACLIfSet([
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey($path),
 				'Metadata' => $metadata,

--- a/lib/Lib/Trait/S3ObjectTrait.php
+++ b/lib/Lib/Trait/S3ObjectTrait.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Robin Appelman <robin@icewind.nl>
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Florent <florent@coppint.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <robin@icewind.nl>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+// namespace OC\Files\ObjectStore;
+namespace OCA\Files_External1\Lib\Trait;
+
+use Aws\S3\Exception\S3MultipartUploadException;
+use Aws\S3\MultipartCopy;
+use Aws\S3\MultipartUploader;
+use Aws\S3\S3Client;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
+use OC\Files\Stream\SeekableHttpStream;
+use Psr\Http\Message\StreamInterface;
+
+trait S3ObjectTrait {
+	/**
+	 * Returns the connection
+	 *
+	 * @return S3Client connected client
+	 * @throws \Exception if connection could not be made
+	 */
+	abstract protected function getConnection();
+
+	abstract protected function getCertificateBundlePath(): ?string;
+	abstract protected function getSSECParameters(bool $copy = false): array;
+
+	/**
+	 * @param string $urn the unified resource name used to identify the object
+	 *
+	 * @return resource stream with the read data
+	 * @throws \Exception when something goes wrong, message will be logged
+	 * @since 7.0.0
+	 */
+	public function readObject($urn) {
+		$fh = SeekableHttpStream::open(function ($range) use ($urn) {
+			$command = $this->getConnection()->getCommand('GetObject', [
+				'Bucket' => $this->bucket,
+				'Key' => $urn,
+				'Range' => 'bytes=' . $range,
+			] + $this->getSSECParameters());
+			$request = \Aws\serialize($command);
+			$headers = [];
+			foreach ($request->getHeaders() as $key => $values) {
+				foreach ($values as $value) {
+					$headers[] = "$key: $value";
+				}
+			}
+			$opts = [
+				'http' => [
+					'protocol_version' => $request->getProtocolVersion(),
+					'header' => $headers,
+				]
+			];
+			$bundle = $this->getCertificateBundlePath();
+			if ($bundle) {
+				$opts['ssl'] = [
+					'cafile' => $bundle
+				];
+			}
+
+			if ($this->getProxy()) {
+				$opts['http']['proxy'] = $this->getProxy();
+				$opts['http']['request_fulluri'] = true;
+			}
+
+			$context = stream_context_create($opts);
+			return fopen($request->getUri(), 'r', false, $context);
+		});
+		if (!$fh) {
+			throw new \Exception("Failed to read object $urn");
+		}
+		return $fh;
+	}
+
+
+	/**
+	 * Single object put helper
+	 *
+	 * @param string $urn the unified resource name used to identify the object
+	 * @param StreamInterface $stream stream with the data to write
+	 * @param string|null $mimetype the mimetype to set for the remove object @since 22.0.0
+	 * @throws \Exception when something goes wrong, message will be logged
+	 */
+	protected function writeSingle(string $urn, StreamInterface $stream, string $mimetype = null): void {
+		$this->getConnection()->putObject($this->getPayloadWithACLIfSet([
+			'Bucket' => $this->bucket,
+			'Key' => $urn,
+			'Body' => $stream,
+			'ACL' => 'private',
+			'ContentType' => $mimetype,
+			'StorageClass' => $this->storageClass,
+		]) + $this->getSSECParameters());
+	}
+
+
+	/**
+	 * Multipart upload helper that tries to avoid orphaned fragments in S3
+	 *
+	 * @param string $urn the unified resource name used to identify the object
+	 * @param StreamInterface $stream stream with the data to write
+	 * @param string|null $mimetype the mimetype to set for the remove object
+	 * @throws \Exception when something goes wrong, message will be logged
+	 */
+	protected function writeMultiPart(string $urn, StreamInterface $stream, string $mimetype = null): void {
+		$uploader = new MultipartUploader($this->getConnection(), $stream, [
+			'bucket' => $this->bucket,
+			'key' => $urn,
+			'part_size' => $this->uploadPartSize,
+			'params' => [
+				'ContentType' => $mimetype,
+				'StorageClass' => $this->storageClass,
+			] + $this->getSSECParameters(),
+		]);
+
+		try {
+			$uploader->upload();
+		} catch (S3MultipartUploadException $e) {
+			// if anything goes wrong with multipart, make sure that you don´t poison and
+			// slow down s3 bucket with orphaned fragments
+			$uploadInfo = $e->getState()->getId();
+			if ($e->getState()->isInitiated() && (array_key_exists('UploadId', $uploadInfo))) {
+				$this->getConnection()->abortMultipartUpload($uploadInfo);
+			}
+			throw new \OCA\DAV\Connector\Sabre\Exception\BadGateway("Error while uploading to S3 bucket", 0, $e);
+		}
+	}
+
+
+	/**
+	 * @param string $urn the unified resource name used to identify the object
+	 * @param resource $stream stream with the data to write
+	 * @param string|null $mimetype the mimetype to set for the remove object @since 22.0.0
+	 * @throws \Exception when something goes wrong, message will be logged
+	 * @since 7.0.0
+	 */
+	public function writeObject($urn, $stream, string $mimetype = null) {
+		$psrStream = Utils::streamFor($stream);
+
+		// ($psrStream->isSeekable() && $psrStream->getSize() !== null) evaluates to true for a On-Seekable stream
+		// so the optimisation does not apply
+		$buffer = new Psr7\Stream(fopen("php://memory", 'rwb+'));
+		Utils::copyToStream($psrStream, $buffer, $this->putSizeLimit);
+		$buffer->seek(0);
+		if ($buffer->getSize() < $this->putSizeLimit) {
+			// buffer is fully seekable, so use it directly for the small upload
+			$this->writeSingle($urn, $buffer, $mimetype);
+		} else {
+			$loadStream = new Psr7\AppendStream([$buffer, $psrStream]);
+			$this->writeMultiPart($urn, $loadStream, $mimetype);
+		}
+	}
+
+	/**
+	 * @param string $urn the unified resource name used to identify the object
+	 * @return void
+	 * @throws \Exception when something goes wrong, message will be logged
+	 * @since 7.0.0
+	 */
+	public function deleteObject($urn) {
+		$this->getConnection()->deleteObject([
+			'Bucket' => $this->bucket,
+			'Key' => $urn,
+		]);
+	}
+
+	public function objectExists($urn) {
+		return $this->getConnection()->doesObjectExist($this->bucket, $urn, $this->getSSECParameters());
+	}
+
+	public function copyObject($from, $to, array $options = []) {
+		$sourceMetadata = $this->getConnection()->headObject([
+			'Bucket' => $this->getBucket(),
+			'Key' => $from,
+		] + $this->getSSECParameters());
+
+		$size = (int)($sourceMetadata->get('Size') ?? $sourceMetadata->get('ContentLength'));
+
+		if ($this->useMultipartCopy && $size > $this->copySizeLimit) {
+			$copy = new MultipartCopy($this->getConnection(), [
+				"source_bucket" => $this->getBucket(),
+				"source_key" => $from
+			], array_merge($this->getPayloadWithACLIfSet([
+				"bucket" => $this->getBucket(),
+				"key" => $to,
+				"params" => $this->getSSECParameters() + $this->getSSECParameters(true),
+				"source_metadata" => $sourceMetadata
+			]), $options));
+			$copy->copy();
+		} else {
+			$this->getConnection()->copy($this->getBucket(), $from, $this->getBucket(), $to, 'private', array_merge([
+				'params' => $this->getSSECParameters() + $this->getSSECParameters(true),
+				'mup_threshold' => PHP_INT_MAX,
+			], $options));
+		}
+	}
+}

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -103,7 +103,9 @@ function writeParameterInput($parameter, $options, $classes = []) {
 		default: ?>
 			<?php if ($is_optional) {
 				$classes[] = 'optional';
-			} ?>
+			}
+			$classes[] = $parameter->getType();
+			?>
 			<input type="text"
 				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -45,6 +45,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 	}
 	$placeholder = $parameter->getText();
 	$is_optional = $parameter->isFlagSet(DefinitionParameter::FLAG_OPTIONAL);
+	$classes[] = $parameter->getType();
 
 	switch ($parameter->getType()) {
 		case DefinitionParameter::VALUE_PASSWORD: ?>
@@ -103,9 +104,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 		default: ?>
 			<?php if ($is_optional) {
 				$classes[] = 'optional';
-			}
-			$classes[] = $parameter->getType();
-			?>
+			} ?>
 			<input type="text"
 				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -82,6 +82,24 @@ function writeParameterInput($parameter, $options, $classes = []) {
 			/>
 			<?php
 			break;
+		case DefinitionParameter::VALUE_SELECT; ?>
+			<?php if ($is_optional) {
+				$classes[] = 'optional';
+			} ?>
+			<select
+				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				data-parameter="<?php p($parameter->getName()); ?>"
+			>
+				<?php foreach ($parameter->getOptions() as $optionValue => $optionText): ?>
+					<option value="<?php p($optionValue); ?>"
+						<?php if ($optionValue === $value): ?> selected="selected"<?php endif; ?>
+					>
+						<?php p($optionText); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+			<?php
+			break;
 		default: ?>
 			<?php if ($is_optional) {
 				$classes[] = 'optional';

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -53,7 +53,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 				$classes[] = 'optional';
 			} ?>
 			<input type="password"
-				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				<?php if (!empty($classes)): ?> class="<?php implode(' ', $classes); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 				value="<?php p($value); ?>"
 				placeholder="<?php p($placeholder); ?>"
@@ -66,7 +66,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 			<label>
 			<input type="checkbox"
 				id="<?php p($checkboxId); ?>"
-				<?php if (!empty($classes)): ?> class="checkbox <?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				<?php if (!empty($classes)): ?> class="checkbox <?php implode(' ', $classes); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 				<?php if ($value === true): ?> checked="checked"<?php endif; ?>
 			/>
@@ -77,7 +77,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 			break;
 		case DefinitionParameter::VALUE_HIDDEN: ?>
 			<input type="hidden"
-				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				<?php if (!empty($classes)): ?> class="<?php implode(' ', $classes); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 				value="<?php p($value); ?>"
 			/>
@@ -88,7 +88,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 				$classes[] = 'optional';
 			} ?>
 			<select
-				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				<?php if (!empty($classes)): ?> class="<?php implode(' ', $classes); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 			>
 				<?php foreach ($parameter->getOptions() as $optionValue => $optionText): ?>
@@ -106,7 +106,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 				$classes[] = 'optional';
 			} ?>
 			<input type="text"
-				<?php if (!empty($classes)): ?> class="<?php p(implode(' ', $classes)); ?>"<?php endif; ?>
+				<?php if (!empty($classes)): ?> class="<?php implode(' ', $classes); ?>"<?php endif; ?>
 				data-parameter="<?php p($parameter->getName()); ?>"
 				value="<?php p($value); ?>"
 				placeholder="<?php p($placeholder); ?>"


### PR DESCRIPTION
This overrides the default ACL being set to 'private' and instead introduces a configurable option against the bucket to facilitate the default ACL for a bucket.